### PR TITLE
docs: add Claude Code installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ A Model Context Protocol (MCP) server for Cairo and Starknet development assista
 
 ## Quick Start
 
+### Install via Claude Code
+
+```bash
+# Install Cairo Coder MCP
+claude mcp add cairo-coder -e CAIRO_CODER_API_KEY=YOUR-API-KEY-HERE -- npx -y @kasarlabs/cairo-coder-mcp
+```
+
+**Note**: Replace `YOUR-API-KEY-HERE` with your actual API key from [cairo-coder.com](https://cairo-coder.com)
+
+### Manual Usage
+
 Use this MCP server directly with npx:
 
 ```bash


### PR DESCRIPTION
### Summary
- Added quick installation command for Cairo Coder MCP using Claude Code CLI
- Makes setup more streamlined for Claude Code users

### Changes
- Updated README.md with claude mcp add command in Quick Start section
- Retained existing manual installation method as an alternative
- Added note to replace placeholder API key with actual key from cairo-coder.com

### Why this change?
- Claude Code users can now install Cairo Coder MCP with a single command that automatically configures the MCP server with their API key

### Testing
- Command follows Claude Code MCP installation conventions
- Syntax verified against Claude Code documentation